### PR TITLE
Improve commit messages whe incrementing versions

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -22,7 +22,7 @@ module.exports = settings => {
             [service]: version
           };
         })
-        .then(data => writeFile(settings, data, `Update ${service} to ${version}\n\n${process.env.DRONE_COMMIT_MESSAGE}`))
+        .then(data => writeFile(settings, data, `[${service}] ${process.env.DRONE_COMMIT_MESSAGE}`))
         .catch(e => {
           if (!(e instanceof UnchangedError)) {
             throw e;


### PR DESCRIPTION
Drone doesn't display the full commit message, only the first line, so make sure the first line of the upstream commit message is still the first line. This means we can see which builds correspond to which actual changes when reviewing Drone build history and Slack alerts.