### PR TITLE
Improve downstream commit message

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -7,6 +7,13 @@ class UnchangedError extends Error {
   }
 }
 
+const parseCommitMessage = msg => {
+  if (msg.match(/^Merge pull request/)) {
+    return msg.split('\n').slice(1).join('\n').trim();
+  }
+  return msg;
+};
+
 module.exports = settings => {
 
   return {
@@ -22,7 +29,7 @@ module.exports = settings => {
             [service]: version
           };
         })
-        .then(data => writeFile(settings, data, `[${service}] ${process.env.DRONE_COMMIT_MESSAGE}`))
+        .then(data => writeFile(settings, data, `[${service}] ${parseCommitMessage(process.env.DRONE_COMMIT_MESSAGE)}`))
         .catch(e => {
           if (!(e instanceof UnchangedError)) {
             throw e;


### PR DESCRIPTION
If the first line of the commit message is `Merge pull request...` (and it normally is) then get rid of that and use the rest of the commit message which is the actually useful bit.